### PR TITLE
fix: Make hotswap footprints SMD.

### DIFF
--- a/mbk.pretty/Choc-1.25u.kicad_mod
+++ b/mbk.pretty/Choc-1.25u.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-1.25u (layer F.Cu) (tedit 603B3E99)
+  (attr smd)
   (fp_text reference 1.25u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )

--- a/mbk.pretty/Choc-1.5u.kicad_mod
+++ b/mbk.pretty/Choc-1.5u.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-1.5u (layer F.Cu) (tedit 603B3E90)
+  (attr smd)
   (fp_text reference 1.5u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )

--- a/mbk.pretty/Choc-1.75u.kicad_mod
+++ b/mbk.pretty/Choc-1.75u.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-1.75u (layer F.Cu) (tedit 603B3EA1)
+  (attr smd)
   (fp_text reference 1.75u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )

--- a/mbk.pretty/Choc-1u.kicad_mod
+++ b/mbk.pretty/Choc-1u.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-1u (layer F.Cu) (tedit 603B3EA9)
+  (attr smd)
   (fp_text reference 1u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )

--- a/mbk.pretty/Choc-2.25u.kicad_mod
+++ b/mbk.pretty/Choc-2.25u.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-2.25u (layer F.Cu) (tedit 603B3EC5)
+  (attr smd)
   (fp_text reference 2.25u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )

--- a/mbk.pretty/Choc-2.75u.kicad_mod
+++ b/mbk.pretty/Choc-2.75u.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-2.75u (layer F.Cu) (tedit 603B3CF6)
+  (attr smd)
   (fp_text reference 2.75u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )

--- a/mbk.pretty/Choc-2u-vertical.kicad_mod
+++ b/mbk.pretty/Choc-2u-vertical.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-2u-vertical (layer F.Cu) (tedit 6076E361)
+  (attr smd)
   (fp_text reference 2u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )

--- a/mbk.pretty/Choc-2u.kicad_mod
+++ b/mbk.pretty/Choc-2u.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-2u (layer F.Cu) (tedit 603B3CCA)
+  (attr smd)
   (fp_text reference 2u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )

--- a/mbk.pretty/Choc-6.25u.kicad_mod
+++ b/mbk.pretty/Choc-6.25u.kicad_mod
@@ -1,4 +1,5 @@
 (module Choc-6.25u (layer F.Cu) (tedit 603B3C95)
+  (attr smd)
   (fp_text reference 6.25u (at 0 -7.14375 180) (layer Dwgs.User)
     (effects (font (size 1 1) (thickness 0.2)))
   )


### PR DESCRIPTION
Tested only on KiCad 7.x, should be tested on KiCad 6.x as well to be sure.

Needed to be sure the assembly attribute is right, useful when automating pick and place for assembly, etc.